### PR TITLE
sjyn/48/meal-plan-scrolling

### DIFF
--- a/recipiece_frontend/src/page/MealPlanView/MealPlanViewPage.tsx
+++ b/recipiece_frontend/src/page/MealPlanView/MealPlanViewPage.tsx
@@ -152,6 +152,7 @@ export const MealPlanViewPage: FC = () => {
       },
       {
         keepDirtyValues: isEditing,
+        keepValues: isEditing,
       }
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Fixes #48 

Add a `keepValues` as well as `keepDirtyValues` to the `useEffect` that is resetting form data when the data array changes